### PR TITLE
feat: support Node 17.x and greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 __httpntlm__ is a Node.js library to do HTTP NTLM authentication
 
-It's a port from the Python libary [python-ntml](https://code.google.com/p/python-ntlm/)
+It's a port from the Python libary [python-ntml](https://code.google.com/p/python-ntlm/) with added NTLMv2 support.
 
 ## Donate
 
@@ -96,8 +96,12 @@ if you already got the encrypted password,you should use this two param to repla
 
 You can also pass along all other options of [httpreq](https://github.com/SamDecrock/node-httpreq), including custom headers, cookies, body data, ... and use POST, PUT or DELETE instead of GET.
 
+## NTLMv2
 
-
+When NTLMv2 extended security and target information can be negotiated with the server, this library assumes
+the server supports NTLMv2 and creates responses according to the NTLMv2 specification (the actually supported
+NTLM version cannot be negotiated).
+Otherwise, NTLMv1 or NTLMv1 with NTLMv2 extended security will be used.
 
 ## Advanced
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,66 @@
+{
+  "name": "httpntlm",
+  "version": "1.7.7",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "httpntlm",
+      "version": "1.7.7",
+      "dependencies": {
+        "crypto-js": "^4.1.1",
+        "httpreq": ">=0.4.22",
+        "js-md4": "^0.3.2",
+        "underscore": "~1.12.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
+    "node_modules/httpreq": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.5.2.tgz",
+      "integrity": "sha512-2Jm+x9WkExDOeFRrdBCBSpLPT5SokTcRHkunV3pjKmX/cx6av8zQ0WtHUMDrYb6O4hBFzNU6sxJEypvRUVYKnw==",
+      "engines": {
+        "node": ">= 6.15.1"
+      }
+    },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="
+    },
+    "node_modules/underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    }
+  },
+  "dependencies": {
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
+    "httpreq": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.5.2.tgz",
+      "integrity": "sha512-2Jm+x9WkExDOeFRrdBCBSpLPT5SokTcRHkunV3pjKmX/cx6av8zQ0WtHUMDrYb6O4hBFzNU6sxJEypvRUVYKnw=="
+    },
+    "js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="
+    },
+    "underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "description": "httpntlm is a Node.js library to do HTTP NTLM authentication",
   "version": "1.7.7",
   "dependencies": {
+    "crypto-js": "^4.1.1",
     "httpreq": ">=0.4.22",
+    "js-md4": "^0.3.2",
     "underscore": "~1.12.1"
   },
   "author": {


### PR DESCRIPTION
Node 17.x switched to OpenSSL 3.0, which removed support for MD4 hashes and DES-ECB ciphers, which NTLM auth relies upon. In order to use the built-in `crypto` module with Node 17.x+ users were forced to enable the legacy SSL module, which isn't great from a security standpoint nor is it a long-term solution.

This PR makes it so MD5 is provided by the `js-md5` package and `DES-ECB` is provided by the `crypto-js` package, such that the built-in Node `crypto` package does not need to be used. 